### PR TITLE
Update the version of regex library in requirements.txt

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ You will need Python 3.6 and above (64-bit).
 1. Install [CamelTools](https://github.com/CAMeL-Lab/camel_tools#install-using-pip).
 2. Install requirements.
 ```
-pip install requirements
+pip install -r requirements.txt
 ```
 
 ## Usage

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ PyArabic==0.6.10
 pytest==6.1.1
 python-editor==1.0.4
 python-Levenshtein==0.12.0
-regex==2020.9.27
+regex==2022.3.2
 scikit-learn==0.23.2
 scipy==1.5.2
 tqdm==4.50.2


### PR DESCRIPTION
ARETA is giving the following error because of the current version requirement of `regex` library (`regex==2020.9.27`). You can fix this by installing the latest version of the library (`regex==2022.3.2`).

```bash
(areta) gi372@Gos-MacBook-Pro arabic_error_type_annotation % python annotate_err_type_ar.py sample/sys_sample.txt sample/ref_sample.txt
Traceback (most recent call last):
  File "annotate_err_type_ar.py", line 4, in <module>
    from scripts.annotation.an_annote_sys_ref import annote_ref_sys
  File "/Users/gi372/Research/arabic_error_type_annotation/scripts/annotation/an_annote_sys_ref.py", line 1, in <module>
    from scripts.annotation.an_annotate_error_type import annotate
  File "/Users/gi372/Research/arabic_error_type_annotation/scripts/annotation/an_annotate_error_type.py", line 2, in <module>
    from scripts.explainability.ex_get_explanation_raw_correct import explain_error
  File "/Users/gi372/Research/arabic_error_type_annotation/scripts/explainability/ex_get_explanation_raw_correct.py", line 5, in <module>
    from scripts.annotation.an_multi_word import get_explained_error_subclass
  File "/Users/gi372/Research/arabic_error_type_annotation/scripts/annotation/an_multi_word.py", line 7, in <module>
    import nltk
  File "/Users/gi372/opt/anaconda3/envs/areta/lib/python3.8/site-packages/nltk/__init__.py", line 137, in <module>
    from nltk.text import *
  File "/Users/gi372/opt/anaconda3/envs/areta/lib/python3.8/site-packages/nltk/text.py", line 29, in <module>
    from nltk.tokenize import sent_tokenize
  File "/Users/gi372/opt/anaconda3/envs/areta/lib/python3.8/site-packages/nltk/tokenize/__init__.py", line 65, in <module>
    from nltk.tokenize.casual import TweetTokenizer, casual_tokenize
  File "/Users/gi372/opt/anaconda3/envs/areta/lib/python3.8/site-packages/nltk/tokenize/casual.py", line 272, in <module>
    class TweetTokenizer:
  File "/Users/gi372/opt/anaconda3/envs/areta/lib/python3.8/site-packages/nltk/tokenize/casual.py", line 357, in TweetTokenizer
    def WORD_RE(self) -> regex.Pattern:
AttributeError: module 'regex' has no attribute 'Pattern'
```